### PR TITLE
from __future__ import print_function for Python 3

### DIFF
--- a/duckencoder.py
+++ b/duckencoder.py
@@ -23,23 +23,17 @@ class DuckEncoder:
                         if len(l) == 0:
                                 continue
 
-                        key, _, val = l.partition("=")
+                        key, val = l.split("=", 1)
                         result_dict[key.strip()] = val.strip()
 
                 return result_dict
-
-        @staticmethod
-        def altReadResource(filename):
-                with open(filename, "r") as f:
-                        lines = (line.strip().split("//")[0].partition("=") for line in f)
-                        return {line[0].strip(): line[-1].strip() for line in lines if line}
 
         @staticmethod
         def parseScriptLine(line, keyProp, langProp):
                 result = ""
 
                 # split line into command and arguments
-                cmd, _, args = line.partition(" ")
+                cmd, args = line.partition(" ", 1)
                 cmd = cmd.strip()
                 args = args.strip()
 

--- a/duckencoder.py
+++ b/duckencoder.py
@@ -33,7 +33,7 @@ class DuckEncoder:
                 result = ""
 
                 # split line into command and arguments
-                cmd, args = line.strip(" ", 1)
+                cmd, args = line.split(" ", 1)
                 cmd = cmd.strip()
                 args = args.strip()
 
@@ -58,7 +58,7 @@ class DuckEncoder:
                                 return ""
 
                         # split away delay argument from remaining string
-                        delay, _, chars = args.strip(" ", 1)
+                        delay, _, chars = args.split(" ", 1)
 
                         # build delaystr
                         delay = int(delay.strip())

--- a/duckencoder.py
+++ b/duckencoder.py
@@ -263,7 +263,7 @@ class DuckEncoder:
                                     "VOLUMEDOWN": "MEDIA_VOLUME_DEC",
                                     "SCROLLLOCK": "SCROLL_LOCK",
                                     "NUMLOCK": "NUM_LOCK",
-                                    "CAPSLOCK": "CAPS_LOCK"}.get(keyinstr, keyinstr[0:1])
+                                    "CAPSLOCK": "CAPS_LOCK"}.get(keyinstr, keyinstr[0:1].upper())
 
                         # second attempt
                         key_entry = "KEY_" + keyinstr.strip()

--- a/duckencoder.py
+++ b/duckencoder.py
@@ -33,7 +33,7 @@ class DuckEncoder:
                 result = ""
 
                 # split line into command and arguments
-                cmd, args = line.split(" ", 1)
+                cmd, _, args = line.partition(" ")
                 cmd = cmd.strip()
                 args = args.strip()
 

--- a/duckencoder.py
+++ b/duckencoder.py
@@ -33,7 +33,7 @@ class DuckEncoder:
                 result = ""
 
                 # split line into command and arguments
-                cmd, args = line.partition(" ", 1)
+                cmd, args = line.strip(" ", 1)
                 cmd = cmd.strip()
                 args = args.strip()
 
@@ -58,7 +58,7 @@ class DuckEncoder:
                                 return ""
 
                         # split away delay argument from remaining string
-                        delay, _, chars = args.partition(" ")
+                        delay, _, chars = args.strip(" ", 1)
 
                         # build delaystr
                         delay = int(delay.strip())


### PR DESCRIPTION
altReadResource() uses a generator and a dict comprehension to do what readResource() does but I can not be 100% sure that it handles all corner cases so I left readResource() in place for now.

* Use str.partition() instead of str.split() when you want both halves.
* Use dict lookup instead of long if blocks.
* Simplify with `or`
* Use ternary if
