### PR TITLE
Update duckencoder.py

### DIFF
--- a/duckencoder.py
+++ b/duckencoder.py
@@ -560,7 +560,7 @@ def main(argv):
                 sys.stdout.write(result)
         else:
                 # write to ofile
-                with open(ofile, "w") as f:
+                with open(ofile, "wb") as f:
                         f.write(result)
 
 


### PR DESCRIPTION
Write the output file with binary type. That will not add '\r' before '\n', when the script runs in windows system.
If you run the old one in windows system, the letter 'G' will be converted to '0xb 0xa 0x2', which actrually '0xa 0x2'.
